### PR TITLE
feat: Don't break keep-in-touch links at icons

### DIFF
--- a/assets/static/style.css
+++ b/assets/static/style.css
@@ -172,3 +172,7 @@ img:hover {
     align-items: center;
     gap: 16px;
 }
+
+a .icon {
+    text-decoration: none;
+}

--- a/assets/static/style.css
+++ b/assets/static/style.css
@@ -175,4 +175,5 @@ img:hover {
 
 a .icon {
     text-decoration: none;
+    vertical-align: middle;
 }

--- a/templates/home.html
+++ b/templates/home.html
@@ -33,7 +33,6 @@
             </section>
     </section>
 </section>
-
 <section class="hero is-medium">
     <div class="hero-body">
         <div class="mailing-list block">
@@ -62,23 +61,24 @@
                 </div>
             </form>
         </div>
-        <div class="columns mt-6">
-            <div class="column icon-text">
+        <div class="level has-text-centered mt-4">
+            <div class="level-item">
                 <a href="https://hachyderm.io/@pycascades">
-                <span class="icon has-text-primary" aria-hidden="true"><span class="fa-brands fa-mastodon fa-2xl"></span>&nbsp;&nbsp;&nbsp;</span>Follow us on Mastodon
+                <span class="icon has-text-primary" aria-hidden="true"><span class="fa-brands fa-mastodon fa-xl" ></span>&nbsp;&nbsp;&nbsp;</span>Follow us on Mastodon
                 </a>
             </div>
-            <div class="column icon-text">
+            <div class="level-item">
                 <a href="{{ '/news@atom/news'|url }}" type="application/atom+xml" rel="alternate" title="Sitewide Atom feed">
-                <span class="icon has-text-primary" aria-hidden="true"><span class="fa-solid fa-rss fa-2xl"></span>&nbsp;&nbsp;&nbsp;</span>Add us to your RSS feed
+                <span class="icon has-text-primary" aria-hidden="true"><span class="fa-solid fa-rss fa-xl"></span>&nbsp;&nbsp;&nbsp;</span>Add us to your RSS feed
                 </a>
             </div>
-            <div class="column icon-text">
+            <div class="level-item"> 
                 <a href="https://join.slack.com/t/pycascades/shared_invite/zt-1l5libchy-RyQi1Kh0PS8DXCfhxhHZhQ">
-                <span class="icon has-text-primary" aria-hidden="true"><span class="fa-brands fa-slack fa-2xl"></span>&nbsp;&nbsp;&nbsp;</span>Join us on Slack
+                <span class="icon has-text-primary" aria-hidden="true"><span class="fa-brands fa-slack fa-xl"></span>&nbsp;&nbsp;&nbsp;</span>Join us on Slack
                 </a>
             </div>
         </div>
     </div>
+</section>
 </main>
 {% endblock %}

--- a/templates/home.html
+++ b/templates/home.html
@@ -64,21 +64,18 @@
         </div>
         <div class="columns mt-6">
             <div class="column icon-text">
-                <span class="icon has-text-primary" aria-hidden="true"><span class="fa-brands fa-mastodon fa-2xl">&nbsp;</span></span>
                 <a href="https://hachyderm.io/@pycascades">
-                Follow us on Mastodon
+                <span class="icon has-text-primary" aria-hidden="true"><span class="fa-brands fa-mastodon fa-2xl"></span>&nbsp;&nbsp;&nbsp;</span>Follow us on Mastodon
                 </a>
             </div>
             <div class="column icon-text">
-                <span class="icon has-text-primary" aria-hidden="true"><span class="fa-solid fa-rss fa-2xl">&nbsp;</span></span>
                 <a href="{{ '/news@atom/news'|url }}" type="application/atom+xml" rel="alternate" title="Sitewide Atom feed">
-                Add our news to your RSS feed 
+                <span class="icon has-text-primary" aria-hidden="true"><span class="fa-solid fa-rss fa-2xl"></span>&nbsp;&nbsp;&nbsp;</span>Add us to your RSS feed
                 </a>
             </div>
             <div class="column icon-text">
-                <span class="icon has-text-primary" aria-hidden="true"><span class="fa-brands fa-slack fa-2xl">&nbsp;</span></span>
                 <a href="https://join.slack.com/t/pycascades/shared_invite/zt-1l5libchy-RyQi1Kh0PS8DXCfhxhHZhQ">
-                Join our Slack workspace
+                <span class="icon has-text-primary" aria-hidden="true"><span class="fa-brands fa-slack fa-2xl"></span>&nbsp;&nbsp;&nbsp;</span>Join us on Slack
                 </a>
             </div>
         </div>


### PR DESCRIPTION
- make mastodon/slack/atom link icons stay in line
- wordsmith links to make them more cohesive
before: 
<img width="776" height="287" alt="image" src="https://github.com/user-attachments/assets/4dad80db-b099-4173-afd3-1d935b2c011f" />
<img width="755" height="415" alt="image" src="https://github.com/user-attachments/assets/108a33ff-9162-4194-9fe0-2362c57111a7" />

after: 
<img width="905" height="344" alt="image" src="https://github.com/user-attachments/assets/a7a61a4b-6d4f-4b56-83b0-c909f872af5c" />
<img width="750" height="356" alt="image" src="https://github.com/user-attachments/assets/7e43e219-9cd5-4b78-990d-93aaef92652f" />

