### PR TITLE
Add /coc/ copy of code of conduct

### DIFF
--- a/content/coc/contents.lr
+++ b/content/coc/contents.lr
@@ -1,0 +1,169 @@
+_model: page
+---
+title: Code of Conduct
+---
+anchors:
+The Principles|principles
+Applicability|applicability
+Speakers, Presenters, and Open-Space Organizers|speakers
+Sponsors, Affiliates, and Exhibitors|sponsors
+Weapons Policy|weapons
+Video Backgrounds|video-backgrounds
+Young Attendees|young-attendees
+Reporting|reporting
+Online Platforms|online-platforms
+Thanks|thanks
+---
+body:
+
+PyCascades is a regional conference made up of a mixture of professionals and volunteers from all over the world, working on every aspect of the mission - including mentorship, teaching and connecting people.
+
+Diversity is one of our huge strengths, but it can also lead to communication issues. To support a welcoming environment for all, regardless of individual differences, we have a few ground rules that we ask people to adhere to when they participate in this community's activities. These rules apply equally to founders, organizers, moderators, sponsors, and affiliates -- in short, to all participants.
+
+This isn't an exhaustive list of things that you must do, or can't do. Rather, take it in the spirit in which it's intended. It's a guide to make it easier to enrich all of us and the technical communities in which we participate, and which we represent.
+
+<div class="heading-wrapper">
+<h2 id="principles">The principles</h2>
+<a href="#principles" class="anchor-link">
+  <span aria-hidden="true" class="fa-solid fa-link anchor-icon"></span>
+  <span class="hidden">Section titled The principles</span>
+</a>  
+</div>
+
+*   **Be friendly and welcoming.** We strive to be a community that welcomes and supports people of all backgrounds and identities. This includes, but is not limited to, members of any race, ethnicity, culture, national origin, color, immigration status, social and economic class, educational level, sex, sexual orientation, gender identity and expression, age, size, family status, political belief, religion, and mental and physical ability.
+*   **Be respectful.** Not all of us will agree all the time, but disagreement is no excuse for poor behavior and poor manners. We might all experience some frustration now and then, but we cannot allow that frustration to turn into a personal attack. It’s important to remember that a community where people feel uncomfortable or threatened is not a productive one. Members of the Python community should be respectful when dealing with other members as well as with people outside the community.
+*   **Be careful in the words that you choose.** We are a community of professionals, and we conduct ourselves professionally. Be kind to others. Do not insult or put down other participants, individually or as a group. Harassment and other exclusionary behavior aren't acceptable. This includes, but is not limited to:
+    *   Violent threats or language directed against another person or yourself.
+    *   Discriminatory jokes and language.
+    *   Posting sexually explicit or violent material.
+    *   Posting (or threatening to post) other people's personally identifying information ("doxing").
+    *   Personal insults, especially those using racist or sexist terms.
+    *   Unwelcome sexual attention.
+    *   Deliberate intimidation, stalking, or following.
+    *   Harassing photography or recording, or photographing or recording people who have explicitly declined to be recorded.
+    *   Inappropriate physical contact.
+    *   Advocating for, or encouraging, any of the above behavior.
+    *   Repeated harassment of others. In general, if someone asks you to stop, then stop.
+
+<div class="heading-wrapper">
+<h2 id="applicability">Where does the Code of Conduct Apply?</h2>
+<a href="#applicability" class="anchor-link">
+  <span aria-hidden="true" class="fa-solid fa-link anchor-icon"></span>
+  <span class="hidden">Section titled Applicability</span>
+</a>  
+</div>
+
+This code of conduct applies to all spaces managed by PyCascades. This includes:
+
+*   Conferences (including social events and peripheral activities, both virtual and in-person)
+*   Unconferences and sprints
+*   Meetups
+*   Workshops
+*   Presentation materials used in talks or sessions
+*   Slack
+*   Mailing lists
+*   GitHub
+*   Social media hashtags
+*   meetup.com discussion boards
+*   Any other forums the community uses for communication.
+
+In addition, violations of this code outside these spaces may affect a person's ability to participate within them.
+
+<div class="heading-wrapper">
+<h3 id="speakers">Speakers, presenters, and open space organizers</h3>
+<a href="#speakers" class="anchor-link">
+  <span aria-hidden="true" class="fa-solid fa-link anchor-icon"></span>
+  <span class="hidden">Section titled Speakers</span>
+</a>  
+</div>
+
+Speakers, presenters, and those organizing open spaces or similar events are expected to uphold the community guidelines. Please let a member of staff know immediately if there are any issues during one of these events. Presentations, open spaces, and similar events will generally not be stopped for one-time gaffes or minor problems, although a staff member will speak to the presenter afterward and we will include any incidents in our transparency report. However, staff will take immediate action to politely and calmly stop any presentation or event that repeatedly or seriously violates our code of conduct policy.
+
+<div class="heading-wrapper">
+<h3 id="sponsors">Sponsors, affiliates, and exhibitors</h3>
+<a href="#sponsors" class="anchor-link">
+  <span aria-hidden="true" class="fa-solid fa-link anchor-icon"></span>
+  <span class="hidden">Section titled Sponsors</span>
+  </a>
+</div>
+
+When you sponsor a PyCascades event, we welcome you as a member of our community, and we expect you to be respectful to the community you operate within.
+
+All exhibitors in the expo hall, sponsor or vendor booths, virtual spaces or similar activities are also subject to the code of conduct. In particular, exhibitors should not use sexualized images, activities, or other material. Booth staff (including volunteers) must not use sexualized clothing/uniforms/costumes, or otherwise create a sexualized environment.
+
+In addition, sponsors and affiliates of conference, meetups, and online activities should not employ aggressive recruiting techniques, invasive marketing behavior, or similar actions towards community members. In case of violations, sponsors might be sanctioned and expelled from the event or activity with no return of the sponsorship contribution.
+
+<div class="heading-wrapper">
+<h2 id="weapons">Weapons Policy</h2>
+<a href="#weapons" class="anchor-link">
+  <span aria-hidden="true" class="fa-solid fa-link anchor-icon"></span>
+  <span class="hidden">Section titled Weapons</span>
+  </a>
+</div>
+
+No weapons are allowed at conference venues, including but not limited to explosives (including fireworks), guns, and large knives such as those used for hunting or display, as well as any other item used for the purpose of causing injury or harm to others. Anyone seen in possession of one of these items will be asked to leave immediately, and will only be allowed to return without the weapon.
+
+Attendees are further expected to comply with all state and local laws on this matter.
+
+<div class="heading-wrapper">
+<h2 id="video-backgrounds">Video Backgrounds</h2>
+<a href="#video-backgrounds" class="anchor-link">
+  <span aria-hidden="true" class="fa-solid fa-link anchor-icon"></span>
+  <span class="hidden">Section titled Video Backgrounds</span>
+  </a>
+</div>
+
+For those intending to use their webcams, any virtual backgrounds or items on display within the field of view of the webcam must also conform with the code of conduct. Speakers and participants should not have or use any items depicting sexualization, objectification, weaponry, or imagery that represents or espouses hateful rhetoric.
+
+<div class="heading-wrapper">
+<h2 id="young-attendees">Young attendees</h2>
+<a href="#young-attendees" class="anchor-link">
+  <span aria-hidden="true" class="fa-solid fa-link anchor-icon"></span>
+  <span class="hidden">Section titled Young Attendees</span>
+  </a>
+</div>
+
+Attendees of all ages are welcome at PyCascades! Attendees 15 years of age and under are welcome to attend with a legal guardian. Both people should be registered for the conference and have badges. The legal guardian should be with the child at all times and the child should never be left alone at the conference.
+
+<div class="heading-wrapper">
+<h2 id="online-platforms">Online Platforms</h2>
+<a href="#online-platforms" class="anchor-link">
+  <span aria-hidden="true" class="fa-solid fa-link anchor-icon"></span>
+  <span class="hidden">Section titled Online Platforms</span>
+  </a>
+</div>
+
+We typically use platforms such as [Venueless](https://venueless.org/) to stream most of our conference activities online. When possible, we provide the option for attendees to self-report whether they are open to direct messages (DMs) or not. This does not always affect one's ability to receive DMs, so we ask that you please respect others' designation in this regard and refrain from DMing where requested.
+
+<div class="heading-wrapper">
+<h2 id="reporting">What to do in case of violations</h2>
+<a href="#reporting" class="anchor-link">
+  <span aria-hidden="true" class="fa-solid fa-link anchor-icon"></span>
+  <span class="hidden">Section titled Reporting</span>
+  </a>
+</div>
+
+If you believe that someone is violating the Code of Conduct during one of our events, please contact the CoC team immediately, either within Venueless by going to "Get Help" > "Code of Conduct" > "Reach out to us" or by emailing us at [conduct@pycascades.com](mailto:conduct@pycascades.com).
+
+To help us respond in the best way to the situation, please follow the [Code of Conduct Reporting](/about/code-of-conduct-reporting-guide/). The CoC representatives employ the [Code of Conduct Response](/about/code-of-conduct-response-playbook/) to handle reports.
+
+If you believe a member of staff is violating our Code of Conduct, please reach out to the conference chair, Ben ([ben@pycascades.com](mailto:ben@pycascades.com)).
+
+All reports will be kept confidential where legally possible. In some cases a public statement might be required (for example in a CoC transparency report following conferences), but these reports are anonymized and do not include any personally identifying information. In the event of involvement with law enforcement, we will comply with their requests as legally required.
+
+<div class="heading-wrapper">
+<h2 id="thanks">Thanks</h2>
+<a href="#thanks" class="anchor-link">
+  <span aria-hidden="true" class="fa-solid fa-link anchor-icon"></span>
+  <span class="hidden">Section titled Thanks</span>
+  </a>
+</div>
+
+This code of conduct is largely based on the [Write The Docs Code of Conduct](http://www.writethedocs.org/code-of-conduct/), which in turn is based on the [Django Project Code of Conduct](https://www.djangoproject.com/conduct/) and the original text of the Speak Up! project, inspired in its turn by the Fedora Project, as well as the Python Mentorship Project and many others.
+---
+show_in_menu: yes
+---
+sort_index: 3
+---
+related_pages:
+


### PR DESCRIPTION
Copied the code-of-conduct from `/about/code-of-conduct` to `/coc/` so the banners at the conference have valid URLs.