### PR TITLE
Bb/2026 wrap

### DIFF
--- a/content/news/2026-transparency-report/contents.lr
+++ b/content/news/2026-transparency-report/contents.lr
@@ -1,0 +1,53 @@
+title: 2026 Transparency Report
+---
+author: Angel & Ben
+---
+body:
+
+## Code of Conduct
+
+PyCascades aims to continue its legacy of being an inclusive and welcoming conference. Continuing from previous years, we have a code of conduct that applies to all of our attendees, speakers, volunteers, and staff. We also have reporting guidelines available publicly on our website and infrastructure in place. 
+
+### Future Growth
+
+This year we attempted to form our regular Code of Conduct Committee. We looked for someone to be our Diversity Chair for the 2026 conference. We were unsuccessful in this. It meant we did not form a proper committee as we usually do. We did have designated people at the venue and online to report to and introduced them during opening remarks. Next year we are going to prioritize finding our chair early in our process so they can get started on this important work.
+We continue to learn and grow as an organizing team and always strive to do better.
+
+## Incidents
+
+We are happy to report that there were no CoC reports at PyCascades or any of its related activities this year. If something warranted a report and was not please reach out to us right away at conduct@pycascades.com.
+
+## Accessibility
+
+We provided travel grants again this year. We feel it’s important to bring as many people together as possible and that money should not be a barrier to that. We had a large number of applicants this year with many traveling from overseas. 
+Sadly, we were unable to help everyone and our limited funds meant that what we could offer our long distance travellers was insufficient. 
+We were able to assist three attendees this year. While this made a difference in their lives we hope that next year we are able to bring in more people.
+
+### Future Growth
+
+We are already discussing ways to be more up front about what we can offer to grant applicants so we can better match our available resources to attendees who would benefit. We also recognize that money isn't the only barrier people face to attending a conference such as PyCascades. We're continuing to refine the ways in which we support attendees traveling from overseas with the visa process. Additionally we're committed to continuing to offer online participation.
+
+## Diversity
+
+As always, our attendees did a wonderful job in welcoming all to PyCascades. While we do have some metrics regarding diversity obtained through our registration process, our sample size is too small to provide specific numbers. We had responses from a small portion of our registrants. There was a wide variety of responses to our questions regarding family heritage and gender identity.  I did enjoy looking at an audience that was full of many besides white men.
+
+### Future Growth
+
+We have plans to change what and how we ask for diversity information next year. We will simplify and ask merely if the attendee identifies as part of an underrepresented group in tech. It is not up to us to decide whether or not someone who identifies as part of a particular group feels this group is underrepresented or not. 
+
+## Feedback
+
+As organizers, we do our best to anticipate what will make PyCascades as welcoming, accessible, and inclusive as possible. We are just a small group of people so we rely on your feedback to help us improve. We want to hear about the things that need work, not just the good things. If there is an area we could do better, please let us know.
+
+## Acknowledgements
+
+We would like to thank the Django and Write the Docs community for providing us with the framework needed to establish our Code of Conduct and associated procedures. We would also like to thank various members of our community and organizing body who provided constructive feedback about our conduct reporting process, allowing us to improve. Finally, we would like to thank all of our volunteers who served as reportees at the conference in-person and online. These volunteers have to deal with emotionally difficult situations in order to ensure that we continue to have a community that is welcoming to all.
+
+We would also be remiss if we did not document that we received an overwhelming amount of positive feedback about our Code of Conduct, our efforts towards increased accessibility, and the visibility & amplification of women, transgender & non-binary people, people of color, and other underrepresented minorities. We are proud to be a strong example of the diversity present within the Python community.
+
+
+
+---
+pub_date: 2026-05-08
+---
+intro: Our post-conference report on diversity, equity, and inclusion at PyCascades

--- a/databags/conferences.json
+++ b/databags/conferences.json
@@ -1,7 +1,7 @@
 {
     "2026": {
 "city": "Vancouver, BC",
-"upcoming": true,
+"upcoming": false,
 "tickets_available": false,
 "website": "2026.pycascades.com",
 "dates": "March 21st-22nd, 2026"

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -27,6 +27,7 @@ pytest-playwright==0.7.0
 python-slugify==8.0.4
 pytz==2025.2
 requests==2.32.5
+setuptools==81.0.0 # necessary because lekor uses pkg_resources, which was removed in 82.0.0
 text-unidecode==1.3
 typing_extensions==4.15.0
 urllib3==2.5.0


### PR DESCRIPTION
- make 2026 no longer upcoming (this removes the "PyCascades 2026 is here!" link in the sitenav)
- add the transparency report